### PR TITLE
Fix (or permissive) slack webhook url regex

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.1.0
+version=1.1.2
 description=EPAM Report Portal. Slack plugin.
 pluginId = slack
 lombokVersion=1.18.36

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.1.2
+version=1.1.0
 description=EPAM Report Portal. Slack plugin.
 pluginId = slack
 lombokVersion=1.18.36

--- a/src/main/java/com/epam/reportportal/extension/slack/info/impl/PluginInfoProviderImpl.java
+++ b/src/main/java/com/epam/reportportal/extension/slack/info/impl/PluginInfoProviderImpl.java
@@ -102,7 +102,7 @@ public class PluginInfoProviderImpl implements PluginInfoProvider {
 		ruleField.put("required", true);
     Map<String, Object> validation = new HashMap<>();
     validation.put("type", "url");
-    validation.put("regex", "^https:\\/\\/hooks\\.slack\\.com\\/services\\/T[A-Z0-9]{8,10}\\/B[A-Z0-9]{10}\\/[a-zA-Z0-9]{24}$");
+    validation.put("regex", "^https:\\/\\/hooks\\.slack\\.com\\/services\\/T[A-Z0-9]{8,12}\\/B[A-Z0-9]{8,12}\\/[a-zA-Z0-9]{24}$");
     validation.put("errorMessage", "Field is Required. Please provide valid URL");
     ruleField.put("validation", validation);
     details.put(FIELDS_KEY, List.of(ruleField));

--- a/src/main/java/com/epam/reportportal/extension/slack/info/impl/PluginInfoProviderImpl.java
+++ b/src/main/java/com/epam/reportportal/extension/slack/info/impl/PluginInfoProviderImpl.java
@@ -102,7 +102,7 @@ public class PluginInfoProviderImpl implements PluginInfoProvider {
 		ruleField.put("required", true);
     Map<String, Object> validation = new HashMap<>();
     validation.put("type", "url");
-    validation.put("regex", "^https:\\/\\/hooks\\.slack\\.com\\/services\\/T[A-Z0-9]{10}\\/B[A-Z0-9]{10}\\/[a-zA-Z0-9]{24}$");
+    validation.put("regex", "^https:\\/\\/hooks\\.slack\\.com\\/services\\/T[A-Z0-9]{8,10}\\/B[A-Z0-9]{10}\\/[a-zA-Z0-9]{24}$");
     validation.put("errorMessage", "Field is Required. Please provide valid URL");
     ruleField.put("validation", validation);
     details.put(FIELDS_KEY, List.of(ruleField));


### PR DESCRIPTION
## Description
This PR addresses #26 .
The current implementation applies overly strict validation on Slack webhook URLs. As a result, some valid webhook URLs (with a team ID length of 8 or 9 characters instead of exactly 10) are incorrectly rejected.

This update relaxes the validation pattern to properly support all valid Slack webhook formats.

## Changes
Updated the regex pattern for validating Slack webhook URLs.
```java
// before: strictly enforces T + 10 characters
"^https:\\/\\/hooks\\.slack\\.com\\/services\\/T[A-Z0-9]{10}\\/B[A-Z0-9]{10}\\/[a-zA-Z0-9]{24}$"

// after: allows T + 8–10 characters
"^https:\\/\\/hooks\\.slack\\.com\\/services\\/T[A-Z0-9]{8,10}\\/B[A-Z0-9]{10}\\/[a-zA-Z0-9]{24}$"
```